### PR TITLE
[refactor] add "@Suppress("UnstableApiUsage")" for ignore @Incubatig warnings

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,7 +15,7 @@ android {
             useSupportLibrary = true
         }
     }
-
+    @Suppress("UnstableApiUsage")
     buildTypes {
         val release by getting {
             isMinifyEnabled = false

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+@Suppress("UnstableApiUsage")
 dependencyResolutionManagement {
     repositories {
         google()


### PR DESCRIPTION
 it's just a friendly warning, that you are using the Incubating class. Let's look into the definition:
"Indicates that a feature is incubating. This means that the feature is currently a work-in-progress and may change at any time."

So don't worry, use it, and eventually update it in the future. Probably, it will be marked as stable in some future Android Studio and plugin versions.

> 
I removed this warning by `@Suppress("UnstableApiUsage")`