### PR TITLE
Optimize/price change colors in market list

### DIFF
--- a/library/designsystem/src/main/java/ir/composenews/designsystem/component/MarketItem.kt
+++ b/library/designsystem/src/main/java/ir/composenews/designsystem/component/MarketItem.kt
@@ -42,8 +42,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color.Companion.Green
-import androidx.compose.ui.graphics.Color.Companion.Red
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
@@ -51,6 +49,10 @@ import coil.compose.rememberAsyncImagePainter
 import ir.composenews.designsystem.R
 import ir.composenews.designsystem.preview.ThemePreviews
 import ir.composenews.designsystem.theme.ComposeNewsTheme
+import ir.composenews.designsystem.theme.darkDownTrendRed
+import ir.composenews.designsystem.theme.darkUptrendGreen
+import ir.composenews.designsystem.theme.lightDownTrendRed
+import ir.composenews.designsystem.theme.lightUptrendGreen
 import kotlinx.coroutines.delay
 import java.util.Locale
 
@@ -192,7 +194,8 @@ private fun MarketItemCard(
                     Text(
                         text = "$priceChangePercentage24h %",
                         style = MaterialTheme.typography.bodyLarge,
-                        color = if (priceChangePercentage24h.contains("-")) Red else Green,
+                        color = if (priceChangePercentage24h.contains("-")) if (isSystemInDarkTheme()) darkDownTrendRed else lightDownTrendRed
+                        else if (isSystemInDarkTheme()) darkUptrendGreen else lightUptrendGreen,
                     )
                 }
             }
@@ -215,7 +218,8 @@ private fun ArrowIconUpOrDown(priceChangePercentage24h: String) {
             painterResource(id = R.drawable.baseline_arrow_upward_24)
         },
         contentDescription = "",
-        tint = if (priceChangePercentage24h.contains("-")) Red else Green,
+        tint = if (priceChangePercentage24h.contains("-")) if (isSystemInDarkTheme()) darkDownTrendRed else lightDownTrendRed
+        else if (isSystemInDarkTheme()) darkUptrendGreen else lightUptrendGreen,
     )
 }
 

--- a/library/designsystem/src/main/java/ir/composenews/designsystem/theme/Color.kt
+++ b/library/designsystem/src/main/java/ir/composenews/designsystem/theme/Color.kt
@@ -67,3 +67,7 @@ val md_theme_dark_scrim = Color(0xFF000000)
 // custom colors
 val graphColor = Color(0xFF6750A4)
 val lightGraphColor = graphColor.copy(alpha = 0.5f)
+val lightUptrendGreen = Color(0xFF4CAF50)
+val darkUptrendGreen = Color(0xFF00A86B)
+val lightDownTrendRed = Color(0xFFE50000)
+val darkDownTrendRed = Color(0xFFFF1919)


### PR DESCRIPTION
**This pull request introduces dynamic color selection for the price change indicator in our app. The goal is to improve the visual representation of price trends and enhance the user experience based on the system theme (light or dark mode).**

**Changes Made**

Added four new colors to our theme:

1. `lightUptrendGreen` for indicating an upward price trend in light mode.
2. `darkUptrendGreen` for indicating an upward price trend in dark mode.
3. `lightDownTrendRed` for indicating a downward price trend in light mode.
4. `darkDownTrendRed` for indicating a downward price trend in dark mode.

I have tested the changes on some different dynamic light and dark themes to ensure that the selected colors work well with our app's design and provide a clear representation of price trends.

Screenshots:

![Shot 0002](https://github.com/Kaaveh/ComposeNews/assets/53356529/c3e3720b-3b7f-416f-a22b-73826c5580fd)
![Shot 0001](https://github.com/Kaaveh/ComposeNews/assets/53356529/8a495ba7-43ed-418a-9d97-ebe20c289c46)
![Shot 0003](https://github.com/Kaaveh/ComposeNews/assets/53356529/bbddfcd6-aa2a-42cc-ae9f-cfb23bad0050)
![Shot 0004](https://github.com/Kaaveh/ComposeNews/assets/53356529/fb37115c-daf5-4462-855d-be47b43b6f3d)

Thank you for your review and feedback.

#145 

