### PR TITLE
Only run Danger checks on PRs from the same repository

### DIFF
--- a/.github/workflows/danger_checks.yml
+++ b/.github/workflows/danger_checks.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   danger:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR modifies the Danger checks workflow to only run on pull requests originating from the same
 repository. This prevents unnecessary checks on forks.
 
 fix #128 