### PR TITLE
[#268] Refactor SwipeToDismissBox initial value

### DIFF
--- a/library/designsystem/src/main/java/ir/composenews/designsystem/component/MarketItem.kt
+++ b/library/designsystem/src/main/java/ir/composenews/designsystem/component/MarketItem.kt
@@ -82,7 +82,7 @@ fun MarketItem(
             }
         },
         positionalThreshold = { positionalThreshold },
-        initialValue = SwipeToDismissBoxValue.EndToStart,
+        initialValue = SwipeToDismissBoxValue.Settled,
     )
 
     if (showFavoriteList) {


### PR DESCRIPTION
Fix #268

The crash happens because starting the swipe state as EndToStart means the component immediately assumes a dismissed position without valid layout anchors. This leads to internal calculations—specifically when determining offsets for placement—producing a NaN value that then fails when converted to an integer (hence “Cannot round NaN value”).