### PR TITLE
add: bug and feature request issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,72 @@
+name: Bug Report
+description: File a bug report to help us improve the project.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to file a bug report!
+        Please make sure to fill in all required fields below so we can help you faster.
+
+  - type: checkboxes
+    id: issue-check
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search the issues to check if someone has already reported this bug or not.
+      options:
+        - label: I have searched the existing issues
+          required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Please describe the bug clearly. What did you expect to happen, and what actually happened?
+      placeholder: Tell us what you observed and what you expected instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: Provide a list of steps to reproduce the issue. Include code, screenshots, or configuration as needed.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. Scroll down to '...'
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: Describe what you expected to happen instead of the observed behavior.
+      placeholder: I expected it to...
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Please provide details about your setup.
+      placeholder: |
+        - OS: [e.g. Android 13, iOS 16, Windows 11]
+        - Device: [e.g. Samsung Galaxy S21, iPhone 13]
+        - App version: [e.g. 1.2.3]
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logcat output
+      description: Please paste any relevant logcat output or console errors. No need to add backticks, it will be formatted automatically.
+      render: shell
+
+  - type: input
+    id: screenshots
+    attributes:
+      label: Screenshots (optional)
+      description: If applicable, add a link to a screenshot or drag and drop it directly in this issue.
+      placeholder: Drag and drop images here or paste a link.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -41,13 +41,6 @@ body:
       required: true
 
   - type: textarea
-    id: expected-behavior
-    attributes:
-      label: Expected Behavior
-      description: Describe what you expected to happen instead of the observed behavior.
-      placeholder: I expected it to...
-
-  - type: textarea
     id: environment
     attributes:
       label: Environment
@@ -63,10 +56,3 @@ body:
       label: Relevant logcat output
       description: Please paste any relevant logcat output or console errors. No need to add backticks, it will be formatted automatically.
       render: shell
-
-  - type: input
-    id: screenshots
-    attributes:
-      label: Screenshots (optional)
-      description: If applicable, add a link to a screenshot or drag and drop it directly in this issue.
-      placeholder: Drag and drop images here or paste a link.

--- a/.github/ISSUE_TEMPLATE/docs_report.yml
+++ b/.github/ISSUE_TEMPLATE/docs_report.yml
@@ -1,0 +1,18 @@
+name: Documentation
+description: Suggest improvements or report issues in the documentation
+title: "[Docs]: "
+labels: ["documentation"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem with the documentation
+      description: What’s wrong or confusing in the docs?
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Your suggestion
+      description: How would you improve it?

--- a/.github/ISSUE_TEMPLATE/enhance_report.yml
+++ b/.github/ISSUE_TEMPLATE/enhance_report.yml
@@ -1,0 +1,54 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+title: "[Enhance]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to suggest a new feature!  
+        Please fill out the form below as completely as possible.
+
+  - type: checkboxes
+    id: issue-check
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search the existing issues to see if someone has already requested this feature.
+      options:
+        - label: I have searched the existing issues
+          required: true
+
+  - type: textarea
+    id: describe-problem
+    attributes:
+      label: Describe the problem
+      description: Is your feature request related to a problem? Please describe what you're trying to solve.
+      placeholder: I'm always frustrated when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the solution
+      description: Describe the solution you would like to see implemented. Please be as clear and specific as possible.
+      placeholder: I'd like the app to...
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe alternatives you've considered
+      description: Have you considered any alternative solutions or features? Please describe them.
+      placeholder: I've also thought about...
+
+  - type: dropdown
+    id: interest
+    attributes:
+      label: Would you like to work on this feature?
+      description: Let us know if you're interested in helping develop or contribute to this feature.
+      options:
+        - Yes, I'm interested in working on this feature
+        - No, I don't wish to contribute to this feature
+      default: 0
+    validations:
+      required: true


### PR DESCRIPTION
This pull request adds two GitHub issue templates to help users file better reports:

- **Bug Report**: A structured form for reporting bugs with fields for reproduction steps, logs, and environment details.
- **Feature Request**: A form for requesting enhancements, including problem description, proposed solution, and an option to express interest in contributing.
