### PR TITLE
[#292] Update Kotest to 6.0.3

### DIFF
--- a/feature/marketdetail/src/test/java/ir/composenews/marketdetail/MarketDetailViewModelTest.kt
+++ b/feature/marketdetail/src/test/java/ir/composenews/marketdetail/MarketDetailViewModelTest.kt
@@ -37,7 +37,7 @@ class MarketDetailViewModelTest : StringSpec({
     val dispatcherProvider = TestDispatcherProvider(testScheduler)
     lateinit var viewModel: MarketDetailViewModel
 
-    listeners(MainCoroutineListener())
+    extension(MainCoroutineListener())
 
     beforeEach {
         viewModel = MarketDetailViewModel(

--- a/feature/marketlist/src/test/java/ir/composenews/marketlist/MarketListViewModelTest.kt
+++ b/feature/marketlist/src/test/java/ir/composenews/marketlist/MarketListViewModelTest.kt
@@ -36,7 +36,7 @@ class MarketListViewModelTest : StringSpec({
     val dispatcherProvider = TestDispatcherProvider(testScheduler)
     lateinit var viewModel: MarketListViewModel
 
-    listeners(MainCoroutineListener())
+    extension(MainCoroutineListener())
 
     beforeEach {
         viewModel = MarketListViewModel(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,7 +66,7 @@ adaptive = "0.26.2-beta"
 ktor = "3.0.1"
 konsist = "0.16.1"
 
-kotest = "5.9.1"
+kotest = "6.0.3"
 espressoCore = "3.6.1"
 
 [libraries]


### PR DESCRIPTION
- Updated the version of Kotest from 5.9.1 to 6.0.3 in `gradle/libs.versions.toml`.